### PR TITLE
适配联网搜索功能，但仅在使用`curl`调用时才生效

### DIFF
--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -122,7 +122,7 @@ async function handleEmbeddings(req, apiKey) {
         model,
         content: { parts: { text } },
 		  tools: [{
-		    "googleSearch": {}
+		    "google_search": {}
 		  }],
         outputDimensionality: req.dimensions,
       }))
@@ -342,7 +342,7 @@ const transformRequest = async (req) => ({
   safetySettings: safetySettings(req.model),
   generationConfig: transformConfig(req),
   tools: [{
-    "googleSearch": {}
+    "google_search": {}
   }],
 });
 

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -121,6 +121,9 @@ async function handleEmbeddings(req, apiKey) {
       "requests": req.input.map(text => ({
         model,
         content: { parts: { text } },
+		  tools: [{
+		    "googleSearch": {}
+		  }],
         outputDimensionality: req.dimensions,
       }))
     })
@@ -199,7 +202,7 @@ const harmCategory = [
 
 const safetySettings = (modelName) => {
   let threshold = modelName?.includes('2.0') && modelName === 'gemini-2.0-flash-exp' ? 'OFF' : 'BLOCK_NONE';
-  
+
   return harmCategory.map(category => ({
     category,
     threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_ONLY_HIGH" : threshold

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -141,7 +141,7 @@ async function handleEmbeddings(req, apiKey) {
   return new Response(body, fixCors(response));
 }
 
-const DEFAULT_MODEL = "gemini-1.5-pro-latest";
+const DEFAULT_MODEL = "gemini-1.5-flash-latest";
 async function handleCompletions(req, apiKey) {
   let model = DEFAULT_MODEL;
   switch (true) {
@@ -338,9 +338,7 @@ const transformRequest = async (req) => ({
   ...await transformMessages(req.messages),
   safetySettings: safetySettings(req.model),
   generationConfig: transformConfig(req),
-  tools: req.tools = [{
-    "google_search": {}
-  }],
+  tools: [{"google_search": {}}]
 });
 
 const generateChatcmplId = () => {

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -121,9 +121,9 @@ async function handleEmbeddings(req, apiKey) {
       "requests": req.input.map(text => ({
         model,
         content: { parts: { text } },
-		  tools: [{
-		    "google_search": {}
-		  }],
+        tools: [{
+            "google_search": {}
+        }],
         outputDimensionality: req.dimensions,
       }))
     })

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -338,7 +338,9 @@ const transformRequest = async (req) => ({
   ...await transformMessages(req.messages),
   safetySettings: safetySettings(req.model),
   generationConfig: transformConfig(req),
-  tools: req.tools,
+  tools: [{
+    "google_search": {}
+  }],
 });
 
 const generateChatcmplId = () => {

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -121,9 +121,6 @@ async function handleEmbeddings(req, apiKey) {
       "requests": req.input.map(text => ({
         model,
         content: { parts: { text } },
-        tools: [{
-            "google_search": {}
-        }],
         outputDimensionality: req.dimensions,
       }))
     })
@@ -202,7 +199,7 @@ const harmCategory = [
 
 const safetySettings = (modelName) => {
   let threshold = modelName?.includes('2.0') && modelName === 'gemini-2.0-flash-exp' ? 'OFF' : 'BLOCK_NONE';
-
+  
   return harmCategory.map(category => ({
     category,
     threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_ONLY_HIGH" : threshold
@@ -341,7 +338,7 @@ const transformRequest = async (req) => ({
   ...await transformMessages(req.messages),
   safetySettings: safetySettings(req.model),
   generationConfig: transformConfig(req),
-  tools: [{
+  tools: req.tools = [{
     "google_search": {}
   }],
 });

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -339,7 +339,7 @@ const transformRequest = async (req) => ({
   safetySettings: safetySettings(req.model),
   generationConfig: transformConfig(req),
   tools: [{
-    "google_search": {}
+    "googleSearch": {}
   }],
 });
 


### PR DESCRIPTION
更改详见提交差异。

我使用如下命令调用：
```bash
curl --location 'https://***.deno.dev/v1/chat/completions' \
--header 'Authorization: Bearer ****' \
--data '{
    "messages": [
        {
            "role": "system",
            "content": "使用中文回答问题"
        },
        {
            "role": "user",
            "content": "中国发布六代机，你怎么看，结合新闻"
        }
    ],
    "model": "gemini-2.0-flash-exp"
}'
```
完全可以获得Google 搜索出来的数据。然而在其他客户端（如[NeatChat](https://github.com/tianzhentech/NeatChat)等）。麻烦作者大佬跟进一下，也可以写一个判断，模型名带`-search`时才启用。
# 不胜感激，望接纳我这个小commit！