### PR TITLE
Google search 功能完善。

### DIFF
--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -155,7 +155,7 @@ async function handleCompletions(req, apiKey) {
   }
   if (req.model == "gemini-2.0-flash-exp-search") {
     model = "gemini-2.0-flash-exp",
-    tools = [{"google_search":{}}]
+    req.tools = [{"google_search":{}}]
   }
   const TASK = req.stream ? "streamGenerateContent" : "generateContent";
   let url = `${BASE_URL}/${API_VERSION}/models/${model}:${TASK}`;

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -205,7 +205,8 @@ const safetySettings = (modelName) => {
   
   return harmCategory.map(category => ({
     category,
-    threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_ONLY_HIGH" : threshold
+    // threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_ONLY_HIGH" : threshold
+    threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_NONE" : threshold
   }));
 }
 

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -150,9 +150,12 @@ async function handleCompletions(req, apiKey) {
     case req.model.startsWith("models/"):
       model = req.model.substring(7);
       break;
-    case req.model.startsWith("gemini-"):
-    case req.model.startsWith("learnlm-"):
+    case req.model.startsWith("gemini-") || req.model.startsWith("learnlm-"):
       model = req.model;
+  }
+  if (req.model == "gemini-2.0-flash-exp-search") {
+    model = "gemini-2.0-flash-exp",
+    tools = [{"google_search":{}}]
   }
   const TASK = req.stream ? "streamGenerateContent" : "generateContent";
   let url = `${BASE_URL}/${API_VERSION}/models/${model}:${TASK}`;

--- a/src/api_proxy/worker.mjs
+++ b/src/api_proxy/worker.mjs
@@ -202,11 +202,11 @@ const harmCategory = [
 
 const safetySettings = (modelName) => {
   let threshold = modelName?.includes('2.0') && modelName === 'gemini-2.0-flash-exp' ? 'OFF' : 'BLOCK_NONE';
-  
+
   return harmCategory.map(category => ({
     category,
-    // threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_ONLY_HIGH" : threshold
-    threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_NONE" : threshold
+    threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_ONLY_HIGH" : threshold
+    // threshold: category === "HARM_CATEGORY_CIVIC_INTEGRITY" ? "BLOCK_NONE" : threshold
   }));
 }
 


### PR DESCRIPTION
如题所示，已支持通过自定义模型名称来开启Google搜索接地功能。仅需在模型名后自定义添加一个`-search`即可。如：
```
gemini-2.0-flash-exp -> gemini-2.0-flash-exp-search
```
**注：需要支持联网搜索的模型才可以**
目前通过`curl`测试是可以使用的
```bash
curl --location 'https://***/v1/chat/completions' \
--header 'Authorization: Bearer ***' \
--data '{
    "messages": [
        {
            "role": "system",
            "content": "使用中文回答问题"
        },
        {
            "role": "user",
            "content": "<Questions>"
        }
    ],
    "model": "gemini-2.0-flash-exp-search"
}'
```
然而在[NeatChat](https://github.com/tianzhentech/NeatChat)却出现莫名问题。

望佬可以merge到一个新分支，更换多个客户端来测试一下
## 望佬能够合并我的一个小commit。